### PR TITLE
Removed the unnecessary variadic operator

### DIFF
--- a/src/Middleware/CanAtLeastMiddleware.php
+++ b/src/Middleware/CanAtLeastMiddleware.php
@@ -14,7 +14,7 @@ class CanAtLeastMiddleware
      * @param  string $permissions
      * @return mixed
      */
-    public function handle($request, Closure $next, ...$permissions)
+    public function handle($request, Closure $next, $permissions)
     {
         $abilities = is_array($permissions) ? $permissions : explode(',', $permissions);
 


### PR DESCRIPTION
As Arjay noted, the `$permission` is always an array, so the variadic operator it's not needed.