### PR TITLE
Allow Users to Directly have permissions as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.3 - 2017-01-10 passionatedreamer19@gmail.com http://facebook.com/muhsaeedparacha
+- Added permissions directly on Users in addition to being on roles.
+- While checking for user permissions, the package checks via two ways $user->permissions() and $user->roles()->permissions
+- use HasRoleAndPermission trait in User Model instead of HasRole
+- Changed HasRole Trait to subtract functionality for User Model, most of that functionality has been copied to HasRoleAndPermission Trait
+
 ## v3.2.0 - 2017-01-05
 - Add github templates.
 - Add php_cs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.3 - 2017-01-10 passionatedreamer19@gmail.com http://facebook.com/muhsaeedparacha
+## v3.3 - 2017-01-10
 - Added permissions directly on Users in addition to being on roles.
 - While checking for user permissions, the package checks via two ways $user->permissions() and $user->roles()->permissions
 - use HasRoleAndPermission trait in User Model instead of HasRole

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Register service provider:
 Yajra\Acl\AclServiceProvider::class
 ```
 
+Register Middlewares: in App\Http\Kernel.php
+```php
+'canAtLeast' => \Yajra\Acl\Middleware\CanAtLeastMiddleware::class,
+'permission' => \Yajra\Acl\Middleware\PermissionMiddleware::class,
+'role' => \Yajra\Acl\Middleware\RoleMiddleware::class,
+```
+
+Define User Trait in User Model
+```php
+...
+use Yajra\Acl\Traits\HasRoleAndPermission;
+
+class User extends Authenticatable
+{
+...
+use HasRoleAndPerimssions; 
+...
+```
+
 Publish assets:
 ```php
 $ php artisan vendor:publish --tag=laravel-acl

--- a/config/acl.php
+++ b/config/acl.php
@@ -10,4 +10,9 @@ return [
      * Permission class used for ACL.
      */
     'permission' => \Yajra\Acl\Models\Permission::class,
+
+    /**
+     * User class used for ACL.
+     */
+    'user' => App\User::class,
 ];

--- a/migrations/2015_12_20_100005_create_permission_user_table.php
+++ b/migrations/2015_12_20_100005_create_permission_user_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePermissionUserTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('permission_user', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('permission_id')->unsigned()->index();
+            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+            $table->integer('user_id')->unsigned()->index();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('permission_user');
+    }
+}

--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -57,7 +57,7 @@ class AclServiceProvider extends ServiceProvider
             foreach ($this->getPermissions() as $permission) {
                 $ability = $permission->slug;
                 $policy  = function ($user) use ($permission) {
-                    return $user->hasRole($permission->roles);
+                    return $user->hasRole($permission->roles) || in_array($permission, $user->permissions);
                 };
 
                 if (Str::contains($permission->slug, '@')) {

--- a/src/Traits/HasPermission.php
+++ b/src/Traits/HasPermission.php
@@ -7,7 +7,7 @@ use Yajra\Acl\Models\Permission;
 trait HasPermission
 {
     /**
-     * Assigns the given permission to the role.
+     * Assigns the given permission to the role or user.
      *
      * @param  int $permissionId
      * @return bool
@@ -36,7 +36,7 @@ trait HasPermission
     }
 
     /**
-     * Revokes the given permission from the role.
+     * Revokes the given permission from the role or user.
      *
      * @param  int|null $permissionId
      * @return bool
@@ -47,7 +47,7 @@ trait HasPermission
     }
 
     /**
-     * Syncs the given permission(s) with the role.
+     * Syncs the given permission(s) with the role or user.
      *
      * @param  array $permissionIds
      * @return array|bool
@@ -58,7 +58,7 @@ trait HasPermission
     }
 
     /**
-     * Revokes all permissions from the role.
+     * Revokes all permissions from the role or user.
      *
      * @return bool
      */
@@ -68,7 +68,7 @@ trait HasPermission
     }
 
     /**
-     * Checks if the role has the given permission.
+     * Checks if the role or user has the given permission.
      *
      * @param  string $permission
      * @return bool
@@ -99,7 +99,7 @@ trait HasPermission
     }
 
     /**
-     * Check if the role has at least one of the given permissions.
+     * Check if the role or user has at least one of the given permissions.
      *
      * @param  array $permission
      * @return bool

--- a/src/Traits/HasPermission.php
+++ b/src/Traits/HasPermission.php
@@ -3,6 +3,7 @@
 namespace Yajra\Acl\Traits;
 
 use Yajra\Acl\Models\Permission;
+use App\User;
 
 trait HasPermission
 {
@@ -35,6 +36,10 @@ trait HasPermission
         return $this->belongsToMany(config('acl.permission', Permission::class))->withTimestamps();
     }
 
+    public function users()
+    {
+        return $this->belongsToMany(config('acl.user', Permission::class))->withTimestamps();
+    }
     /**
      * Revokes the given permission from the role or user.
      *

--- a/src/Traits/HasRole.php
+++ b/src/Traits/HasRole.php
@@ -8,82 +8,6 @@ use Yajra\Acl\Models\Role;
 trait HasRole
 {
     /**
-     * Check if user have access using any of the acl.
-     *
-     * @param  array $acl
-     * @return boolean
-     */
-    public function canAccess(array $acl)
-    {
-        return $this->canAtLeast($acl) || $this->hasRole($acl);
-    }
-
-    /**
-     * Check if user has at least one of the given permissions
-     *
-     * @param  array $permissions
-     * @return bool
-     */
-    public function canAtLeast(array $permissions)
-    {
-        $can = false;
-
-        if (auth()->check()) {
-            foreach ($this->roles as $role) {
-                if ($role->canAtLeast($permissions)) {
-                    $can = true;
-                }
-            }
-        } else {
-            $guest = Role::whereSlug('guest')->first();
-
-            if ($guest) {
-                return $guest->canAtLeast($permissions);
-            }
-        }
-
-        return $can;
-    }
-
-    /**
-     * Check if user has the given role.
-     *
-     * @param string|array $role
-     * @return bool
-     */
-    public function hasRole($role)
-    {
-        if (is_string($role)) {
-            return $this->roles->contains('name', $role);
-        }
-
-        if (is_array($role)) {
-            $roles = $this->getRoleSlugs();
-
-            $intersection      = array_intersect($roles, (array) $role);
-            $intersectionCount = count($intersection);
-
-            return ($intersectionCount > 0) ? true : false;
-        }
-
-        return ! ! $role->intersect($this->roles)->count();
-    }
-
-    /**
-     * Get all user roles.
-     *
-     * @return array|null
-     */
-    public function getRoleSlugs()
-    {
-        if (! is_null($this->roles)) {
-            return $this->roles->pluck('slug')->toArray();
-        }
-
-        return null;
-    }
-
-    /**
      * Attach a role to user using slug.
      *
      * @param $slug
@@ -208,6 +132,8 @@ trait HasRole
         foreach ($this->roles as $role) {
             $permissions[] = $role->getPermissions();
         }
+
+        $permissions[] = $this->permissions->pluck('slug')->toArray();
 
         return call_user_func_array('array_merge', $permissions);
     }

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -114,7 +114,7 @@ trait HasRoleAndPermission
         $permissions = $this->getPermissions();
         $intersection      = array_intersect($permissions, $permission);
 
-        if(count($intersection); > 0){
+        if(count($intersection) > 0){
             return true;
         }
 

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -71,26 +71,26 @@ trait HasRoleAndPermission
         return $this->permissions()->detach();
     }
 
-    /**
-     * Checks if the role or user has the given permission.
-     *
-     * @param  string $permission
-     * @return bool
-     */
-    public function can($permission)
-    {
-        $permissions = $this->getPermissions();
+    // /**
+    //  * Checks if the role or user has the given permission.
+    //  *
+    //  * @param  string $permission
+    //  * @return bool
+    //  */
+    // public function can($permission)
+    // {
+    //     $permissions = $this->getPermissions();
 
-        if (is_array($permission)) {
-            $permissionCount   = count($permission);
-            $intersection      = array_intersect($permissions, $permission);
-            $intersectionCount = count($intersection);
+    //     if (is_array($permission)) {
+    //         $permissionCount   = count($permission);
+    //         $intersection      = array_intersect($permissions, $permission);
+    //         $intersectionCount = count($intersection);
 
-            return ($permissionCount == $intersectionCount) ? true : false;
-        } else {
-            return in_array($permission, $permissions);
-        }
-    }
+    //         return ($permissionCount == $intersectionCount) ? true : false;
+    //     } else {
+    //         return in_array($permission, $permissions);
+    //     }
+    // }
 
     /**
      * Check if user have access using any of the acl.

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -228,16 +228,6 @@ trait HasRoleAndPermission
     }
 
     /**
-     * Model can have many users.
-     *
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function users()
-    {
-        return $ this->belongsToMany(config('acl.user', User::class))->withTimestamps();
-    }
-
-    /**
      * Query scope for user having the given roles.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Yajra\Acl\Traits;
+
+use Illuminate\Support\Str;
+use Yajra\Acl\Models\Role;
+use Yajra\Acl\Models\Permission;
+use App\User;
+
+trait HasRoleAndPermission
+{
+
+    /**
+     * Assigns the given permission to the role or user.
+     *
+     * @param  int $permissionId
+     * @return bool
+     */
+    public function assignPermission($permissionId = null)
+    {
+        $permissions = $this->permissions;
+
+        if (! $permissions->contains($permissionId)) {
+            $this->permissions()->attach($permissionId);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get related permissions.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function permissions()
+    {
+        return $this->belongsToMany(config('acl.permission', Permission::class))->withTimestamps();
+    }
+
+    /**
+     * Revokes the given permission from the role or user.
+     *
+     * @param  int|null $permissionId
+     * @return bool
+     */
+    public function revokePermission($permissionId = null)
+    {
+        return $this->permissions()->detach($permissionId);
+    }
+
+    /**
+     * Syncs the given permission(s) with the role or user.
+     *
+     * @param  array $permissionIds
+     * @return array|bool
+     */
+    public function syncPermissions(array $permissionIds = [])
+    {
+        return $this->permissions()->sync($permissionIds);
+    }
+
+    /**
+     * Revokes all permissions from the role or user.
+     *
+     * @return bool
+     */
+    public function revokeAllPermissions()
+    {
+        return $this->permissions()->detach();
+    }
+
+    /**
+     * Checks if the role or user has the given permission.
+     *
+     * @param  string $permission
+     * @return bool
+     */
+    public function can($permission)
+    {
+        $permissions = $this->getPermissions();
+
+        if (is_array($permission)) {
+            $permissionCount   = count($permission);
+            $intersection      = array_intersect($permissions, $permission);
+            $intersectionCount = count($intersection);
+
+            return ($permissionCount == $intersectionCount) ? true : false;
+        } else {
+            return in_array($permission, $permissions);
+        }
+    }
+
+    /**
+     * Check if user have access using any of the acl.
+     *
+     * @param  array $acl
+     * @return boolean
+     */
+    public function canAccess(array $acl)
+    {
+        return $this->canAtLeast($acl) || $this->hasRole($acl);
+    }
+
+    /**
+     * Check if user has at least one of the given permissions
+     *
+     * @param  array $permissions
+     * @return bool
+     */
+    public function canAtLeast(array $permissions)
+    {
+        $permissions = $this->getPermissions();
+        $intersection      = array_intersect($permissions, $permission);
+
+        if(count($intersection); > 0){
+            return true;
+        }
+
+        $can = false;
+
+        if (auth()->check()) {
+            foreach ($this->roles as $role) {
+                if ($role->canAtLeast($permissions)) {
+                    $can = true;
+                }
+            }
+        } else {
+            $guest = Role::whereSlug('guest')->first();
+
+            if ($guest) {
+                return $guest->canAtLeast($permissions);
+            }
+        }
+
+        return $can;
+
+    }
+
+    /**
+     * Check if user has the given role.
+     *
+     * @param string|array $role
+     * @return bool
+     */
+    public function hasRole($role)
+    {
+        if (is_string($role)) {
+            return $this->roles->contains('name', $role);
+        }
+
+        if (is_array($role)) {
+            $roles = $this->getRoleSlugs();
+
+            $intersection      = array_intersect($roles, (array) $role);
+            $intersectionCount = count($intersection);
+
+            return ($intersectionCount > 0) ? true : false;
+        }
+
+        return ! ! $role->intersect($this->roles)->count();
+    }
+
+    /**
+     * Get all user roles.
+     *
+     * @return array|null
+     */
+    public function getRoleSlugs()
+    {
+        if (! is_null($this->roles)) {
+            return $this->roles->pluck('slug')->toArray();
+        }
+
+        return null;
+    }
+
+    /**
+     * Attach a role to user using slug.
+     *
+     * @param $slug
+     * @return bool
+     */
+    public function attachRoleBySlug($slug)
+    {
+        $role = Role::where('slug', $slug)->first();
+
+        return $this->attachRole($role);
+    }
+
+    /**
+     * Attach a role to user
+     *
+     * @param  Role $role
+     * @return boolean
+     */
+    public function attachRole(Role $role)
+    {
+        return $this->assignRole($role->id);
+    }
+
+    /**
+     * Assigns the given role to the user.
+     *
+     * @param  int $roleId
+     * @return bool
+     */
+    public function assignRole($roleId = null)
+    {
+        $roles = $this->roles;
+
+        if (! $roles->contains($roleId)) {
+            return $this->roles()->attach($roleId);
+        }
+
+        return false;
+    }
+
+    /**
+     * Model can have many roles.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+   public function roles()
+    {
+        return $this->belongsToMany(config('acl.role', Role::class))->withTimestamps();
+    }
+
+    /**
+     * Model can have many users.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function users()
+    {
+        return $ this->belongsToMany(config('acl.user', User::class))->withTimestamps();
+    }
+
+    /**
+     * Query scope for user having the given roles.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array $roles
+     * @return mixed
+     */
+    public function scopeHavingRoles($query, array $roles)
+    {
+        return $query->whereExists(function ($query) use ($roles) {
+            $query->selectRaw('1')
+                  ->from('role_user')
+                  ->whereRaw('role_user.user_id = users.id')
+                  ->whereIn('role_id', $roles);
+        });
+    }
+
+    /**
+     * Revokes the given role from the user using slug.
+     *
+     * @param  string $slug
+     * @return bool
+     */
+    public function revokeRoleBySlug($slug)
+    {
+        $role = Role::where('slug', $slug)->first();
+
+        return $this->roles()->detach($role);
+    }
+
+    /**
+     * Revokes the given role from the user.
+     *
+     * @param  mixed $role
+     * @return bool
+     */
+    public function revokeRole($role = "")
+    {
+        return $this->roles()->detach($role);
+    }
+
+    /**
+     * Syncs the given role(s) with the user.
+     *
+     * @param  array $roles
+     * @return bool
+     */
+    public function syncRoles(array $roles)
+    {
+        return $this->roles()->sync($roles);
+    }
+
+    /**
+     * Revokes all roles from the user.
+     *
+     * @return bool
+     */
+    public function revokeAllRoles()
+    {
+        return $this->roles()->detach();
+    }
+
+    /**
+     * Get all user role permissions.
+     *
+     * @return array|null
+     */
+    public function getPermissions()
+    {
+        $permissions = [[], []];
+
+        foreach ($this->roles as $role) {
+            $permissions[] = $role->getPermissions();
+        }
+
+        $permissions[] = $this->permissions->pluck('slug')->toArray();
+
+        return call_user_func_array('array_merge', $permissions);
+    }
+
+    /**
+     * Magic __call method to handle dynamic methods.
+     *
+     * @param  string $method
+     * @param  array $arguments
+     * @return mixed
+     */
+    public function __call($method, $arguments = [])
+    {
+        // Handle isRoleSlug() methods
+        if (Str::startsWith($method, 'is') and $method !== 'is') {
+            $role = substr($method, 2);
+
+            return $this->isRole($role);
+        }
+
+        // Handle canDoSomething() methods
+        if (Str::startsWith($method, 'can') and $method !== 'can') {
+            $permission = substr($method, 3);
+
+            return $this->can($permission);
+        }
+
+        return parent::__call($method, $arguments);
+    }
+
+    /**
+     * Checks if the user has the given role.
+     *
+     * @param  string $slug
+     * @return bool
+     */
+    public function isRole($slug)
+    {
+        $slug = Str::lower($slug);
+
+        foreach ($this->roles as $role) {
+            if ($role->slug == $slug) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the given entity/model is owned by the user.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $entity
+     * @param string $relation
+     * @return bool
+     */
+    public function owns($entity, $relation = 'user_id')
+    {
+        return $this->id === $entity->{$relation};
+    }
+}


### PR DESCRIPTION
This is my first community contribution and if I do something wrong, please do point it out.

I have allowed the ability for Users to directly have permissions as well in addition to via role. Now users have $user->permissions and the existing $user->roles()->permissions.
Now the User Model needs to use HasRoleAndPermission trait instead of HasRole trait. Has Role trait is now only for the the permissions model and thus any functionality of User Model has been removed from it.
In addition, the HasRoleAndPermission is a combination of HasRole and HasPermission traits, excluding the methods which were strickly for Permission table only, and updated methods of getting permissions via $user->roles()->permissions() as well as $user->permissions.

Gate Policies are also updated to reflect this change and to check for permissions both directly and through roles