### PR TITLE
Add config to skip default migrations.

### DIFF
--- a/config/acl.php
+++ b/config/acl.php
@@ -10,4 +10,6 @@ return [
      * Permission class used for ACL.
      */
     'permission' => \Yajra\Acl\Models\Permission::class,
+
+    'enable_migrations' => true,
 ];

--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -41,7 +41,14 @@ class AclServiceProvider extends ServiceProvider
      */
     protected function publishMigrations()
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../migrations');
+        /**
+         * @note make it possible to write own migrations by making loadMigrations configurable
+         * sometimes its necessary to replace the default migraitons (e.g. multiple user tables)
+         */
+        if (config('acl.enable_migrations', true)) {
+            $this->loadMigrationsFrom(__DIR__ . '/../migrations');
+        }
+
         $this->publishes([
             __DIR__ . '/../migrations' => database_path('migrations'),
         ], 'laravel-acl');


### PR DESCRIPTION
Hello Guys,
i have just added a new configuration parameter, to making it able to disable the default migration.

In some cases it could be useful to disabling them e.g. multiple user tables and polymorphic relations or non default users table migration. Actual the "CreateRoleUserTable"-Migration has a hard dependency to the default users migration, in case of a custom users table it fails to migrate it.