### PR TITLE
Performance: Cache guest role in CanAtLeastDirective

### DIFF
--- a/src/Directives/CanAtLeastDirective.php
+++ b/src/Directives/CanAtLeastDirective.php
@@ -17,11 +17,9 @@ class CanAtLeastDirective extends DirectiveAbstract
             return $this->auth->user()->canAtLeast((array) $permissions);
         }
 
-        $guest = Role::whereSlug('guest')->first();
-        if ($guest) {
-            return $guest->canAtLeast((array) $permissions);
-        }
-
-        return false;
+        static $guest;
+        $guest ??= Role::whereSlug('guest')->first();
+        
+        return $guest?->canAtLeast((array) $permissions) ?? false;
     }
 }


### PR DESCRIPTION
### Summary
This PR optimizes the CanAtLeastDirective by caching the "guest" role 
using a static variable. This prevents repeated database queries each 
time the directive is called during a single request.

### Changes
- Added `static $guest; $guest ??= Role::whereSlug('guest')->first();`
  to cache the guest role.
- Return statement updated to use cached guest role.

### Notes
- No breaking changes.
- Only performance improvement.
